### PR TITLE
Improve GitHub Actions

### DIFF
--- a/.github/workflows/test-dryrun-frontend.yml
+++ b/.github/workflows/test-dryrun-frontend.yml
@@ -1,14 +1,18 @@
-name: Create and publish frontend Docker image
+name: Run unit tests and dry-run image build
 
 on:
+  push:
+    branches:
+      - "main"
+      - "development"
+    paths:
+      - "frontend/**"
   pull_request:
     branches:
       - "main"
       - "development"
     paths:
       - "frontend/**"
-    types:
-      - closed
 
 env:
   REGISTRY: ghcr.io
@@ -16,9 +20,6 @@ env:
 
 jobs:
   test-frontend:
-    # This job should only run if the PR has been merged
-    if: github.event.pull_request.merged == true
-
     runs-on: ubuntu-latest
 
     permissions:
@@ -33,30 +34,15 @@ jobs:
           npm ci
           npm run test
 
-  build-and-push-frontend-image:
-    # This job should only run if the PR has been merged
-    if: github.event.pull_request.merged == true
-
-    needs: [test-frontend]
-
+  dryrun-package-frontend:
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -71,18 +57,11 @@ jobs:
             type=sha,value=${{ github.sha }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
-      - name: Build and push Docker image
+      - name: Try building Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
           context: ./frontend/
-          push: true
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true


### PR DESCRIPTION
- Enable frontend testing on all PRs to core branches (main/development)
- "Secure" frontend release-package by only triggering on a successful PR to a core branch